### PR TITLE
Allow entity-particles to be built on JitPack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,15 @@
 plugins {
+    id "maven"
     id "org.jetbrains.kotlin.jvm" version "1.2.41"
     id "org.jetbrains.kotlin.kapt" version "1.2.41"
     id "com.github.johnrengelman.shadow" version "1.2.4"
-    id "flavor.pie.promptsign" version "1.0.2"
+    id "flavor.pie.promptsign" version "1.0.2" apply false
+}
+
+def isJitpack = System.getenv("JITPACK") != null
+
+if (!isJitpack) {
+    apply plugin: "flavor.pie.promptsign"
 }
 
 group "de.randombyte"
@@ -39,7 +46,10 @@ shadowJar {
     classifier = null // Remove "-all" suffix from output file name
 }
 build.dependsOn shadowJar
-signArchives.dependsOn shadowJar
+install.dependsOn shadowJar
+if (!isJitpack) {
+    signArchives.dependsOn shadowJar
+}
 
 compileKotlin {
     kotlinOptions {


### PR DESCRIPTION
This commits makes two changes:
* Only enable the prompsign plugin when not on JitPack
* Make the maven 'install' task depedent on shadowJar, to ensure that
shadowing happens properly when JitPack runs './gradlew install'