### PR TITLE
Remove strange internal relocation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 shadowJar {
     configurations = [project.configurations.shadow]
 
-    relocate "de.randombyte.entityparticles", "de.randombyte.entityparticles.plugin"
     relocate "kotlin", "de.randombyte.entityparticles.shaded.kotlin"
     relocate "de.randombyte.kosp", "de.randombyte.entityparticles.shaded.kosp"
     relocate "org.bstats", "de.randombyte.entityparticles.shaded.bstats"


### PR DESCRIPTION
This relocation unecessarily breaks any plugins depending on
entity-particles. Additionally, it creates a weird situation where the
package names of public classes changes between development and
production.